### PR TITLE
retain exported NSRunningApplication reference to avoid autorelease

### DIFF
--- a/src/workspace.m
+++ b/src/workspace.m
@@ -22,7 +22,7 @@ void workspace_event_handler_end(void *context)
 
 void *workspace_application_create_running_ns_application(struct process *process)
 {
-    return [NSRunningApplication runningApplicationWithProcessIdentifier:process->pid];
+    return [[NSRunningApplication runningApplicationWithProcessIdentifier:process->pid] retain];
 }
 
 void workspace_application_destroy_running_ns_application(void *ws_context, struct process *process)


### PR DESCRIPTION
(X-fork clone of koekeishiya#973):

Per discussion/thinking outloud in koekeishiya#967 (https://github.com/koekeishiya/yabai/pull/967#issuecomment-888634413 ) with nod from @koekeishiya – Added explicit call to `retain` before returning to C++:

https://developer.apple.com/documentation/objectivec/1418956-nsobject/1571946-retain

this seems to be a better way to fix koekeishiya#920 and possibly other crashes in Monterey (and who knows, maybe even earlier); and probably should have been in 8c9bbbe38978ad1057dfc1cc629476daef99e115 in the first place

I built this (on xorpse/master) and can open and close application without any crash so far on Monterey beta 3 (21A5294g) \*knock on wood\*

 (neither the immediate crashes I was seeing on application launch before, nor the GC-triggered crash as in https://github.com/koekeishiya/yabai/issues/923#issuecomment-885882316 )

---

If this were not needed it would probably introduce a memory leak.

To check I set an lldb breakpoint at https://github.com/koekeishiya/yabai/blob/8777db43b8551e0bc4e5c55d1e15bcbed52501a1/src/workspace.m#L60

Once triggered, I found that:

```
(lldb) p [application retainCount]
(unsigned long long) $3 = 1
```

and

```
(lldb) p (NSObject*)[ application release]
(NSObject *) $5 = nil
(lldb) p (NSObject*)[ application release]
error: Execution was interrupted, reason: EXC_BREAKPOINT (code=1, subcode=0x18d284930).
The process has been returned to the state before expression evaluation.
```

so seems good to me