### PR TITLE
Add macOS 12 (Monterey) version helper, add calls to treat like Big Sur

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -912,7 +912,7 @@ static EVENT_CALLBACK(EVENT_HANDLER_DOCK_DID_RESTART)
 {
     debug("%s:\n", __FUNCTION__);
 
-    if (!workspace_is_macos_bigsur() && scripting_addition_is_installed()) {
+    if (!workspace_is_macos_bigsur() &&!workspace_is_macos_monterey() && scripting_addition_is_installed()) {
         scripting_addition_load();
 
         for (int window_index = 0; window_index < g_window_manager.window.capacity; ++window_index) {

--- a/src/message.c
+++ b/src/message.c
@@ -1022,10 +1022,10 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
         if (value.type == TOKEN_TYPE_INVALID) {
             fprintf(rsp, "%f\n", g_window_manager.window_opacity_duration);
         } else if (value.type == TOKEN_TYPE_FLOAT) {
-            if (!workspace_is_macos_catalina() && !workspace_is_macos_bigsur()) {
+            if (!workspace_is_macos_catalina() && !workspace_is_macos_bigsur() && !workspace_is_macos_monterey()) {
                 g_window_manager.window_opacity_duration = value.float_value;
             } else {
-                daemon_fail(rsp, "'%s' cannot be changed on macOS Catalina/Big Sur because of an Apple bug in the WindowServer\n", COMMAND_CONFIG_OPACITY_DURATION);
+                daemon_fail(rsp, "'%s' cannot be changed on macOS Catalina/Big Sur/Monterey because of an Apple bug in the WindowServer\n", COMMAND_CONFIG_OPACITY_DURATION);
             }
         } else {
             daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.token.length, value.token.text, command.length, command.text, domain.length, domain.text);

--- a/src/osax/sa.h
+++ b/src/osax/sa.h
@@ -29,6 +29,7 @@ bool scripting_addition_set_shadow(uint32_t wid, bool shadow);
 bool scripting_addition_focus_window(uint32_t wid);
 bool scripting_addition_scale_window(uint32_t wid, float x, float y, float w, float h);
 
+extern bool workspace_is_macos_monterey(void);
 extern bool workspace_is_macos_bigsur(void);
 extern bool workspace_is_macos_highsierra(void);
 

--- a/src/osax/sa.m
+++ b/src/osax/sa.m
@@ -122,7 +122,7 @@ static char sa_bundle_plist[] =
 static void scripting_addition_set_path(void)
 {
     NSOperatingSystemVersion os_version = [[NSProcessInfo processInfo] operatingSystemVersion];
-    if (os_version.majorVersion == 11 || os_version.minorVersion >= 14) {
+    if (os_version.majorVersion > 10 || os_version.minorVersion >= 14) {
         snprintf(osax_base_dir, sizeof(osax_base_dir), "%s", "/Library/ScriptingAdditions/yabai.osax");
     } else {
         snprintf(osax_base_dir, sizeof(osax_base_dir), "%s", "/System/Library/ScriptingAdditions/yabai.osax");
@@ -432,7 +432,7 @@ int scripting_addition_load(void)
         return 1;
     }
 
-    if (workspace_is_macos_bigsur()) {
+    if (workspace_is_macos_bigsur() || workspace_is_macos_monterey()) {
         if (!is_root()) {
             warn("yabai: scripting-addition must be loaded as root!\n");
             notify("scripting-addition", "must be loaded as root!");

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -17,6 +17,7 @@ bool workspace_application_is_observable(struct process *process);
 bool workspace_application_is_finished_launching(struct process *process);
 void workspace_application_observe_finished_launching(void *context, struct process *process);
 void workspace_application_observe_activation_policy(void *context, struct process *process);
+bool workspace_is_macos_monterey(void);
 bool workspace_is_macos_bigsur(void);
 bool workspace_is_macos_catalina(void);
 bool workspace_is_macos_mojave(void);

--- a/src/workspace.m
+++ b/src/workspace.m
@@ -101,6 +101,12 @@ bool workspace_application_is_finished_launching(struct process *process)
     }
 }
 
+bool workspace_is_macos_monterey(void)
+{
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+    return (version.majorVersion == 12);
+}
+
 bool workspace_is_macos_bigsur(void)
 {
     NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];

--- a/src/yabai.c
+++ b/src/yabai.c
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
         error("yabai: could not initialize daemon! abort..\n");
     }
 
-    if (!workspace_is_macos_bigsur()) {
+    if (!workspace_is_macos_bigsur() && !workspace_is_macos_monterey()) {
         if (scripting_addition_is_installed()) {
             scripting_addition_load();
         } else {


### PR DESCRIPTION
This moves the ball forward to where:

1. `sudo yabai --install-sa` exits 0 and (apparently) correctly populates `/Library/ScriptingAdditions/yabai.osax`
2. `sudo yabai --load-sa` returns 0 but then yabai reports:
    ![CleanShot 2021-07-29 at 20 29 10@2x](https://user-images.githubusercontent.com/43136/127582614-ec3d0f23-c161-4cfa-bf5c-2e9683194af6.png)

